### PR TITLE
Refactor app-db to nested structure and optimize subscriptions

### DIFF
--- a/src/bb_web_ds_tools/core.cljs
+++ b/src/bb_web_ds_tools/core.cljs
@@ -79,20 +79,32 @@
  ::initialize-db
  (fn [_ _]
    (let [repl-id (str (random-uuid))]
-     {:code "initial code"
-      :repl {:instances {repl-id {:id repl-id
-                                  :code ""
-                                  :output []}}}})))
+     {:user-input {:editor {:default {:code "initial code"}}
+                   :repl {repl-id {:id repl-id
+                                   :code ""
+                                   :output []}}}})))
+
+(rf/reg-sub
+ ::user-input
+ (fn [db]
+   (:user-input db)))
+
+(rf/reg-sub
+ ::editor
+ :<- [::user-input]
+ (fn [user-input]
+   (get-in user-input [:editor :default])))
 
 (rf/reg-sub
  ::code
- (fn [db]
-   (:code db)))
+ :<- [::editor]
+ (fn [editor]
+   (:code editor)))
 
 (rf/reg-event-db
  ::code-changed
  (fn [db [_ new-code]]
-   (assoc db :code new-code)))
+   (assoc-in db [:user-input :editor :default :code] new-code)))
 
 ;; --- Views ---
 


### PR DESCRIPTION
- Refactor `app-db` schema to `[:user-input <component-id> <instance-id>]`.
- Implement layered (optimized) re-frame subscriptions for all views (`malli`, `honeysql`, `vega-lite`, `gemma`, `pyodide`, `repl`, `editor`).
- Fix `core.cljs` to initialize DB with new structure and fix `nav-bar` state.
- Ensure `repl` view uses the new structure for instance management.
- Verify changes with `npx shadow-cljs release app` and E2E test `test/e2e/verify_release.py`.