### PR TITLE
fix(pyodide): correct code retrieval path in execution handler

### DIFF
--- a/src/bb_web_ds_tools/views/pyodide.cljs
+++ b/src/bb_web_ds_tools/views/pyodide.cljs
@@ -90,7 +90,7 @@
 (rf/reg-event-fx
  ::run-code
  (fn [{:keys [db]} _]
-   {:fx [[::execute-python (::code db)]]}))
+   {:fx [[::execute-python (get-in db [:user-input :pyodide :default ::code])]]}))
 
 ;; View
 (defn panel []


### PR DESCRIPTION
The `::run-code` event handler was attempting to retrieve the Python code from the root of the app-db using `(::code db)`, which resulted in `nil` because the code is actually stored in a nested structure `[:user-input :pyodide :default ::code]`.

This caused a `TypeError: expected string or bytes-like object, got 'NoneType'` in Pyodide's internal `textwrap.dedent` function when `runPythonAsync` was called with `null`.

This commit updates the event handler to use `get-in` with the correct path, ensuring the code string is properly passed to the Python runtime.