### PR TITLE
fix(webr): replace incorrect .eval with .evalR and fix output

### DIFF
--- a/src/bb_web_ds_tools/views/r_repl.cljs
+++ b/src/bb_web_ds_tools/views/r_repl.cljs
@@ -77,8 +77,11 @@
 
                                                                 (if (empty? cmd)
                                                                   (.write term prompt)
-                                                                  (-> (.eval webr cmd)
-                                                                      (.then (fn [_]
+                                                                  (-> (.evalR webr cmd (clj->js {:env js/undefined :autoprint true}))
+                                                                      (.then (fn [res]
+                                                                               (try
+                                                                                 (.destroy res)
+                                                                                 (catch js/Error _))
                                                                                (.write term prompt)))
                                                                       (.catch (fn [err]
                                                                                 (.write term (str "\u001b[31mError: " err "\u001b[0m\r\n" prompt)))))))


### PR DESCRIPTION
- Replaces the incorrect `webr.eval()` call with `webr.evalR()`.
- Adds `{autoprint: true}` option to `evalR` to ensure R output is printed to the console (and thus captured by the REPL read loop).
- Adds a `.then` block to destroy the returned `RObject` to prevent memory leaks.
- Fixes the `TypeError: webr.eval is not a function` error reported by the user.