### PR TITLE
Refactor runtime_test to use full map equality assertion

### DIFF
--- a/test/bb_web_ds_tools/runtime_test.cljs
+++ b/test/bb_web_ds_tools/runtime_test.cljs
@@ -11,4 +11,4 @@
     (let [results (atom [])]
       (with-redefs [p/submit (fn [res] (swap! results conj res))]
         (sci/eval-in-main "(+ 1 2)")
-        (is (= "3" (:value (last @results))))))))
+        (is (= {:type :result :value "3"} (last @results)))))))


### PR DESCRIPTION
Refactored `test/bb_web_ds_tools/runtime_test.cljs` to use direct equality checks for immutable data structures instead of checking specific fields. This aligns with the request to "test of pure functions with static values".

Verification:
- Modified `shadow-cljs.edn` to isolate `bb-web-ds-tools.runtime-test`.
- Ran `npm test` successfully with the refactored test.
- Reverted `shadow-cljs.edn`.

---
*PR created automatically by Jules for task [2710804760582045497](https://jules.google.com/task/2710804760582045497) started by @davidpham87*