### PR TITLE
Fix E2E test type inference warnings

### DIFF
--- a/src/verification/dataset_e2e.cljs
+++ b/src/verification/dataset_e2e.cljs
@@ -17,8 +17,8 @@
       (let [chromium (.-chromium pw)]
         (if-not chromium
           (fail "Chromium not found in playwright module")
-          (let [browser (<p! (.launch chromium))
-                page (<p! (.newPage browser))]
+          (let [^js browser (<p! (.launch chromium))
+                ^js page (<p! (.newPage browser))]
             (log "Browser launched.")
 
             (.on page "console" (fn [msg]
@@ -30,50 +30,57 @@
               (<p! (.goto page "http://localhost:8080/"))
 
               (log "Waiting for app to load (checking landing page text)...")
-              (<p! (.waitFor (.getByText page "Swiss Army Knife")))
+              (let [^js el (.getByText page "Swiss Army Knife")]
+                (<p! (.waitFor el)))
 
               (log "Navigating to Datasets via URL...")
               (<p! (.goto page "http://localhost:8080/#/datasets"))
 
               (log "Waiting for + New Dataset button (Sidebar)...")
-              (let [new-btn (.getByRole page "button" #js {:name "+ New Dataset"})]
+              (let [^js new-btn (.getByRole page "button" #js {:name "+ New Dataset"})]
                 (<p! (.waitFor new-btn #js {:timeout 10000})))
 
               (log "Clicking + New Dataset...")
-              (<p! (.click (.getByRole page "button" #js {:name "+ New Dataset"})))
+              (let [^js new-btn (.getByRole page "button" #js {:name "+ New Dataset"})]
+                (<p! (.click new-btn)))
 
               (log "Waiting for Create button (Importer View)...")
-              (let [create-btn (.getByRole page "button" #js {:name "Create"})]
+              (let [^js create-btn (.getByRole page "button" #js {:name "Create"})]
                 (<p! (.waitFor create-btn #js {:timeout 5000})))
 
               (log "Filling Input (Monaco)...")
               ;; Target the editor container
-              (let [editor (.locator page ".monaco-editor")]
+              (let [^js editor (.locator page ".monaco-editor")]
                 (<p! (.click editor))
                  ;; Clear existing text (Ctrl+A, Backspace)
-                (let [body (.locator page "body")]
+                (let [^js body (.locator page "body")]
                   (<p! (.press body "Control+A"))
                   (<p! (.press body "Backspace")))
                  ;; Insert text with valid JSON (comma separated array)
-                (<p! (.insertText (.-keyboard page) "{\"a\": 1, \"b\": [1, 2]}")))
+                (let [^js keyboard (.-keyboard page)]
+                  (<p! (.insertText keyboard "{\"a\": 1, \"b\": [1, 2]}"))))
 
               (log "Selecting JSON format...")
-              (<p! (.click (.getByRole page "button" #js {:name "JSON"})))
+              (let [^js btn (.getByRole page "button" #js {:name "JSON"})]
+                (<p! (.click btn)))
 
               (log "Selecting Tree structure...")
-              (<p! (.click (.getByRole page "button" #js {:name "Tree (Raw)"})))
+              (let [^js btn (.getByRole page "button" #js {:name "Tree (Raw)"})]
+                (<p! (.click btn)))
 
               (log "Clicking Create...")
-              (<p! (.click (.getByRole page "button" #js {:name "Create"})))
+              (let [^js btn (.getByRole page "button" #js {:name "Create"})]
+                (<p! (.click btn)))
 
               (log "Waiting for data table (implies success)...")
               (<p! (.waitForTimeout page 1000))
 
               (log "Clicking Export tab...")
-              (<p! (.click (.getByRole page "button" #js {:name "Export"})))
+              (let [^js btn (.getByRole page "button" #js {:name "Export"})]
+                (<p! (.click btn)))
 
               (log "Verifying Export View...")
-              (let [export-btn (.getByRole page "button" #js {:name "Download"})]
+              (let [^js export-btn (.getByRole page "button" #js {:name "Download"})]
                 (<p! (.waitFor export-btn #js {:timeout 5000}))
                 (log "Download button visible."))
 


### PR DESCRIPTION
Added ^js type hints and split chained interop calls in src/verification/dataset_e2e.cljs to resolve ClojureScript compiler warnings about target type inference in go blocks.

---
*PR created automatically by Jules for task [529939759320174693](https://jules.google.com/task/529939759320174693) started by @davidpham87*