### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSV Injection Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -38,3 +38,8 @@
 **Vulnerability:** User-controlled data exported to CSV/TSV could contain formulas (starting with =, +, -, @) that execute when opened in Excel/Google Sheets.
 **Learning:** Standard regex matching (`re-matches .*`) in ClojureScript/JS does not match newlines by default, allowing bypass via multiline strings.
 **Prevention:** Use `re-find` with start-of-string anchor (`^...`) instead of `re-matches` with `.*`, or enable dot-all mode if full matching is required.
+
+## 2026-01-28 - CSV Injection Bypass
+**Vulnerability:** CSV/TSV formula injection protection could be bypassed using leading whitespace, tabs, newlines, or DDE characters (`|`, `%`).
+**Learning:** Regex anchors (`^`) in standard input validation often fail to account for control characters and whitespace which spreadsheet software ignores before executing formulas.
+**Prevention:** Enhanced the sanitization regex to `#"^[\s\r\n]*[=\+\-@|%]"` to catch these bypasses.

--- a/src/bb_web_ds_tools/utils/dataset_processing.cljs
+++ b/src/bb_web_ds_tools/utils/dataset_processing.cljs
@@ -318,9 +318,9 @@ Line 3: 123-456-7890")
 
 (defn sanitize-value
   "Sanitizes a value for CSV/TSV export to prevent formula injection.
-   Prepends a single quote if the string starts with =, +, -, or @."
+   Prepends a single quote if the string starts with =, +, -, @, |, or % (including leading whitespace/control chars)."
   [v]
-  (if (and (string? v) (re-find #"^[=\+\-@]" v))
+  (if (and (string? v) (re-find #"^[\s\r\n]*[=\+\-@|%]" v))
     (str "'" v)
     v))
 

--- a/test/bb_web_ds_tools/utils/security_test.cljs
+++ b/test/bb_web_ds_tools/utils/security_test.cljs
@@ -1,0 +1,23 @@
+(ns bb-web-ds-tools.utils.security-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [bb-web-ds-tools.utils.dataset-processing :as sut]))
+
+(deftest csv-injection-bypass-test
+  (testing "Sanitize value bypass attempts"
+    ;; Current protection
+    (is (= "'=cmd" (sut/sanitize-value "=cmd")))
+    (is (= "'+cmd" (sut/sanitize-value "+cmd")))
+    (is (= "'-cmd" (sut/sanitize-value "-cmd")))
+    (is (= "'@cmd" (sut/sanitize-value "@cmd")))
+
+    ;; Potential Bypasses
+    ;; Tab injection
+    (is (= "'\t=cmd" (sut/sanitize-value "\t=cmd")) "Tab prefix should be sanitized")
+    ;; Carriage return injection
+    (is (= "'\r=cmd" (sut/sanitize-value "\r=cmd")) "CR prefix should be sanitized")
+    ;; Newline injection
+    (is (= "'\n=cmd" (sut/sanitize-value "\n=cmd")) "LF prefix should be sanitized")
+    ;; Pipe injection (DDE)
+    (is (= "'|cmd" (sut/sanitize-value "|cmd")) "Pipe prefix should be sanitized")
+    ;; Percent injection
+    (is (= "'%cmd" (sut/sanitize-value "%cmd")) "Percent prefix should be sanitized")))


### PR DESCRIPTION
This PR fixes a security vulnerability where CSV Formula Injection protection could be bypassed.

**Vulnerability:**
The previous sanitization only checked for formulas starting directly with `=`, `+`, `-`, or `@`. Attackers could bypass this by prepending whitespace, tabs (`\t`), carriage returns (`\r`), or newlines (`\n`), which spreadsheet software often ignores before executing formulas. Additionally, DDE injection via `|` and `%` was not blocked.

**Fix:**
Updated the `sanitize-value` function in `src/bb_web_ds_tools/utils/dataset_processing.cljs` to use a more robust regex: `#"^[\s\r\n]*[=\+\-@|%]"`.

**Verification:**
- Added a new test file `test/bb_web_ds_tools/utils/security_test.cljs` that verifies the fix against various bypass attempts.
- Ran `npm test` to confirm all tests pass.

**Sentinel Journal:**
- Added entry to `.jules/sentinel.md` documenting the vulnerability and learning.

---
*PR created automatically by Jules for task [17473849496153942845](https://jules.google.com/task/17473849496153942845) started by @davidpham87*