### PR TITLE
Fix failing tests by pinning Storybook dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     },
     "devDependencies": {
         "@pyodide/webpack-plugin": "^1.4.0",
-        "@storybook/addon-essentials": "^8.6.14",
-        "@storybook/addon-interactions": "^8.6.14",
-        "@storybook/react": "^8.6.14",
-        "@storybook/react-webpack5": "^8.6.14",
+        "@storybook/addon-essentials": "8.6.14",
+        "@storybook/addon-interactions": "8.6.14",
+        "@storybook/react": "8.6.14",
+        "@storybook/react-webpack5": "8.6.14",
         "css-loader": "^7.1.2",
         "karma": "^6.4.4",
         "karma-chrome-launcher": "^3.2.0",
@@ -32,7 +32,7 @@
         "prop-types": "^15.8.1",
         "pyodide": "^0.29.0",
         "shadow-cljs": "3.2.1",
-        "storybook": "^8.6.14",
+        "storybook": "8.6.14",
         "style-loader": "^4.0.0",
         "webpack": "^5.103.0",
         "webpack-cli": "^6.0.1"


### PR DESCRIPTION
Pinned Storybook dependencies to `8.6.14` in `package.json` to fix installation errors and allow `npm test` to pass.

---
*PR created automatically by Jules for task [1398645638564802807](https://jules.google.com/task/1398645638564802807) started by @davidpham87*