### PR TITLE
Refactor router tests to use vector equality assertions

### DIFF
--- a/test/bb_web_ds_tools/router_test.cljs
+++ b/test/bb_web_ds_tools/router_test.cljs
@@ -15,11 +15,13 @@
           match-code (r/match-by-path router "/code/pyodide")
           match-malli (r/match-by-path router "/malli/inference")]
 
-      (is (= :code-tab (get-in match-code [:data :name])))
-      (is (= "pyodide" (get-in match-code [:path-params :tab])))
+      (is (= [:code-tab "pyodide"]
+             [(get-in match-code [:data :name])
+              (get-in match-code [:path-params :tab])]))
 
-      (is (= :malli-tab (get-in match-malli [:data :name])))
-      (is (= "inference" (get-in match-malli [:path-params :tab]))))))
+      (is (= [:malli-tab "inference"]
+             [(get-in match-malli [:data :name])
+              (get-in match-malli [:path-params :tab])])))))
 
 (deftest state-sharing-test
   (testing "Encoding and decoding state"
@@ -63,8 +65,9 @@
                   :parameters {:path {:tab "pyodide"}}
                   :query-params {:state encoded}}]
        (rf/dispatch [:bb-web-ds-tools.core/navigated match])
-       (is (= :pyodide @(rf/subscribe [:bb-web-ds-tools.views.code/active-tab])))
-       (is (= "combined" (:custom-key @(rf/subscribe [:bb-web-ds-tools.router-test/test-db]))))))))
+       (is (= [:pyodide "combined"]
+              [@(rf/subscribe [:bb-web-ds-tools.views.code/active-tab])
+               (:custom-key @(rf/subscribe [:bb-web-ds-tools.router-test/test-db]))]))))))
 
 ;; Helper subscription for testing
 (rf/reg-sub ::test-db (fn [db _] db))


### PR DESCRIPTION
Refactored tests in `test/bb_web_ds_tools/router_test.cljs` to use vector equality assertions for cleaner and more concise test code, as per user request. Full object equality was considered but avoided for reitit match objects due to the presence of internal functions and opaque types.

---
*PR created automatically by Jules for task [9320824856619981078](https://jules.google.com/task/9320824856619981078) started by @davidpham87*