### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Mass Assignment in State Sharing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -38,3 +38,8 @@
 **Vulnerability:** User-controlled data exported to CSV/TSV could contain formulas (starting with =, +, -, @) that execute when opened in Excel/Google Sheets.
 **Learning:** Standard regex matching (`re-matches .*`) in ClojureScript/JS does not match newlines by default, allowing bypass via multiline strings.
 **Prevention:** Use `re-find` with start-of-string anchor (`^...`) instead of `re-matches` with `.*`, or enable dot-all mode if full matching is required.
+
+## 2026-01-30 - [Insecure State Deserialization]
+**Vulnerability:** The application blindly merged deserialized state from the URL (`?state=...`) into the global `app-db`, allowing Mass Assignment of any state key (including critical runtime/platform config).
+**Learning:** Re-frame applications often expose their entire `app-db` to merge operations for state restoration, which is risky if not whitelisted.
+**Prevention:** Implemented an allow-list (`allowed-keys`) for shared state and a sanitization function (`sanitize-state`) in the deserialization layer.

--- a/src/bb_web_ds_tools/utils/share.cljs
+++ b/src/bb_web_ds_tools/utils/share.cljs
@@ -2,6 +2,22 @@
   (:require [cognitect.transit :as t]
             ["lz-string" :as lz]))
 
+(def allowed-keys
+  "Set of keys allowed in the shared state to prevent mass assignment vulnerabilities."
+  #{:user-input
+    :bb-web-ds-tools.views.malli/malli
+    :bb-web-ds-tools.views.malli/mobile-view-mode
+    :bb-web-ds-tools.views.honeysql/honeysql
+    :bb-web-ds-tools.views.datasets/datasets
+    :bb-web-ds-tools.views.vega-lite/state
+    :bb-web-ds-tools.views.code/active-tab
+    :bb-web-ds-tools.views.code/mobile-view-mode})
+
+(defn sanitize-state
+  "Filters the state map to only include allowed keys."
+  [state]
+  (select-keys state allowed-keys))
+
 (defn encode-state
   "Encodes a state map using transit and lz-string compression.
 
@@ -21,18 +37,20 @@
 
 (defn decode-state
   "Decodes a compressed string back into a state map.
+   Sanitizes the output to prevent overwriting protected state keys.
 
    Args:
      s (string): The compressed encoded string.
 
    Returns:
-     map: The decoded state, or nil if invalid."
+     map: The decoded and sanitized state, or nil if invalid."
   [s]
   (try
     (let [json-str (lz/decompressFromEncodedURIComponent s)
           reader (t/reader :json)]
       (when json-str
-        (t/read reader json-str)))
+        (some-> (t/read reader json-str)
+                sanitize-state)))
     (catch :default e
       (js/console.error "Error decoding state:" e)
       nil)))

--- a/test/bb_web_ds_tools/router_test.cljs
+++ b/test/bb_web_ds_tools/router_test.cljs
@@ -23,7 +23,7 @@
 
 (deftest state-sharing-test
   (testing "Encoding and decoding state"
-    (let [state {:a 1 :b "test" :c [1 2 3]}
+    (let [state {:user-input {:a 1 :b "test"}}
           encoded (share/encode-state state)
           decoded (share/decode-state encoded)]
       (is (string? encoded))
@@ -47,24 +47,24 @@
 
    (testing "Navigation restores shared state"
      ;; load-shared-state merges the decoded map into the DB root.
-     ;; We will verify this by checking a custom key in the DB.
-     (let [shared-state {:custom-key "restored"}
+     ;; We will verify this by checking a custom key in the DB, wrapped in :user-input to pass validation.
+     (let [shared-state {:user-input {:custom-key "restored"}}
            encoded (share/encode-state shared-state)
            match {:data {:name :landing-page}
                   :query-params {:state encoded}}]
        (rf/dispatch [:bb-web-ds-tools.core/navigated match])
        ;; We subscribe to the full DB to check the root key
-       (is (= "restored" (:custom-key @(rf/subscribe [:bb-web-ds-tools.router-test/test-db]))))))
+       (is (= "restored" (get-in @(rf/subscribe [:bb-web-ds-tools.router-test/test-db]) [:user-input :custom-key])))))
 
    (testing "Navigation with both tab and state works simultaneously"
-     (let [shared-state {:custom-key "combined"}
+     (let [shared-state {:user-input {:custom-key "combined"}}
            encoded (share/encode-state shared-state)
            match {:data {:name :code-tab}
                   :parameters {:path {:tab "pyodide"}}
                   :query-params {:state encoded}}]
        (rf/dispatch [:bb-web-ds-tools.core/navigated match])
        (is (= :pyodide @(rf/subscribe [:bb-web-ds-tools.views.code/active-tab])))
-       (is (= "combined" (:custom-key @(rf/subscribe [:bb-web-ds-tools.router-test/test-db]))))))))
+       (is (= "combined" (get-in @(rf/subscribe [:bb-web-ds-tools.router-test/test-db]) [:user-input :custom-key])))))))
 
 ;; Helper subscription for testing
 (rf/reg-sub ::test-db (fn [db _] db))

--- a/test/bb_web_ds_tools/utils/share_test.cljs
+++ b/test/bb_web_ds_tools/utils/share_test.cljs
@@ -1,0 +1,31 @@
+(ns bb-web-ds-tools.utils.share-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [bb-web-ds-tools.utils.share :as share]))
+
+(deftest sanitize-state-test
+  (testing "Allowed keys are preserved"
+    (let [state {:user-input {:some "data"}
+                 :bb-web-ds-tools.views.malli/malli {:config "foo"}}]
+      (is (= state (share/sanitize-state state)))))
+
+  (testing "Disallowed keys are removed"
+    (let [state {:platform {:mac-os? false}
+                 :runtime {:some "worker"}
+                 :portal {:theme :dark}}
+          sanitized (share/sanitize-state state)]
+      (is (empty? sanitized))))
+
+  (testing "Mixed content is filtered"
+    (let [state {:user-input {:data "ok"}
+                 :platform {:hack "attempt"}
+                 :bb-web-ds-tools.views.datasets/datasets {:items []}}
+          expected {:user-input {:data "ok"}
+                    :bb-web-ds-tools.views.datasets/datasets {:items []}}]
+      (is (= expected (share/sanitize-state state))))))
+
+(deftest decode-state-test
+  (testing "Decoding validates state"
+    (let [malicious-state {:user-input {:a 1} :platform {:b 2}}
+          encoded (share/encode-state malicious-state)
+          decoded (share/decode-state encoded)]
+      (is (= {:user-input {:a 1}} decoded)))))


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Mass Assignment vulnerability in state sharing

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The application blindly merged deserialized state from the URL (`?state=...`) into the global `app-db`, allowing Mass Assignment of any state key (including critical runtime/platform config).
🎯 **Impact:** An attacker could craft a malicious link to overwrite sensitive application state, potentially leading to denial of service, logic bypass, or unexpected behavior.
🔧 **Fix:** Implemented an allow-list (`allowed-keys`) for shared state and a sanitization function (`sanitize-state`) in the deserialization layer.
✅ **Verification:** Added `test/bb_web_ds_tools/utils/share_test.cljs` to verify that disallowed keys are stripped. Updated existing `router_test.cljs` to conform to the new security constraints. Verified all tests pass.

---
*PR created automatically by Jules for task [2855493292883649644](https://jules.google.com/task/2855493292883649644) started by @davidpham87*