### PR TITLE
Fix shadow-cljs source-path warning

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,7 +1,4 @@
-{:source-paths
- ["src" "test" "src/stories"]
-
- :deps true
+{:deps true
 
  :dev-http {8080 {:root "docs"
                   :headers {"Cross-Origin-Opener-Policy" "same-origin"


### PR DESCRIPTION
Removed `:source-paths` from `shadow-cljs.edn` to fix a warning during test compilation. Verified that `npm test` passes (69/69 tests success).

---
*PR created automatically by Jules for task [2984345761361922657](https://jules.google.com/task/2984345761361922657) started by @davidpham87*