### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix state injection via URL

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -38,3 +38,8 @@
 **Vulnerability:** User-controlled data exported to CSV/TSV could contain formulas (starting with =, +, -, @) that execute when opened in Excel/Google Sheets.
 **Learning:** Standard regex matching (`re-matches .*`) in ClojureScript/JS does not match newlines by default, allowing bypass via multiline strings.
 **Prevention:** Use `re-find` with start-of-string anchor (`^...`) instead of `re-matches` with `.*`, or enable dot-all mode if full matching is required.
+
+## 2026-01-31 - [State Injection via URL]
+**Vulnerability:** The `::load-shared-state` event blindly merged decoded JSON from the URL query parameter `?state=` into the application database (`app-db`), allowing attackers to overwrite sensitive keys like `[:platform]` or `[:runtime]`.
+**Learning:** Functions that hydrate application state from untrusted sources (like URL parameters) must explicitly whitelist allowed keys rather than using `merge`.
+**Prevention:** Replaced `(merge db decoded)` with `(merge db (select-keys decoded [:user-input]))`.

--- a/src/bb_web_ds_tools/core.cljs
+++ b/src/bb_web_ds_tools/core.cljs
@@ -73,7 +73,7 @@
  ::load-shared-state
  (fn [db [_ encoded-state]]
    (if-let [decoded (share/decode-state encoded-state)]
-     (merge db decoded)
+     (merge db (select-keys decoded [:user-input]))
      db)))
 
 (rf/reg-event-fx

--- a/test/bb_web_ds_tools/router_test.cljs
+++ b/test/bb_web_ds_tools/router_test.cljs
@@ -47,24 +47,24 @@
 
    (testing "Navigation restores shared state"
      ;; load-shared-state merges the decoded map into the DB root.
-     ;; We will verify this by checking a custom key in the DB.
-     (let [shared-state {:custom-key "restored"}
+     ;; We will verify this by checking a whitelisted key (user-input) in the DB.
+     (let [shared-state {:user-input {:router-test "restored"}}
            encoded (share/encode-state shared-state)
            match {:data {:name :landing-page}
                   :query-params {:state encoded}}]
        (rf/dispatch [:bb-web-ds-tools.core/navigated match])
        ;; We subscribe to the full DB to check the root key
-       (is (= "restored" (:custom-key @(rf/subscribe [:bb-web-ds-tools.router-test/test-db]))))))
+       (is (= "restored" (get-in @(rf/subscribe [:bb-web-ds-tools.router-test/test-db]) [:user-input :router-test])))))
 
    (testing "Navigation with both tab and state works simultaneously"
-     (let [shared-state {:custom-key "combined"}
+     (let [shared-state {:user-input {:router-test "combined"}}
            encoded (share/encode-state shared-state)
            match {:data {:name :code-tab}
                   :parameters {:path {:tab "pyodide"}}
                   :query-params {:state encoded}}]
        (rf/dispatch [:bb-web-ds-tools.core/navigated match])
        (is (= :pyodide @(rf/subscribe [:bb-web-ds-tools.views.code/active-tab])))
-       (is (= "combined" (:custom-key @(rf/subscribe [:bb-web-ds-tools.router-test/test-db]))))))))
+       (is (= "combined" (get-in @(rf/subscribe [:bb-web-ds-tools.router-test/test-db]) [:user-input :router-test])))))))
 
 ;; Helper subscription for testing
 (rf/reg-sub ::test-db (fn [db _] db))

--- a/test/bb_web_ds_tools/security_test.cljs
+++ b/test/bb_web_ds_tools/security_test.cljs
@@ -1,0 +1,49 @@
+(ns bb-web-ds-tools.security-test
+  (:require [cljs.test :refer [deftest is testing use-fixtures]]
+            [day8.re-frame.test :as rf-test]
+            [re-frame.core :as rf]
+            [bb-web-ds-tools.core :as core]
+            [bb-web-ds-tools.utils.share :as share]
+            [bb-web-ds-tools.test-setup :as setup]))
+
+(use-fixtures :each setup/suppress-re-frame-warnings)
+
+;; Helper event/sub for test
+(rf/reg-event-db
+  :test/inject-sensitive-data
+  (fn [db [_ val]]
+    (assoc db :test/sensitive-data val)))
+
+(rf/reg-sub
+  :test/sensitive-data
+  (fn [db _]
+    (:test/sensitive-data db)))
+
+(deftest load-shared-state-security-test
+  (rf-test/run-test-sync
+    (testing "State injection vulnerability"
+      ;; 1. Initialize DB with a sensitive key
+      (rf/dispatch [::core/initialize-db])
+      ;; Manually inject a sensitive key into the DB to simulate existing state
+      (rf/dispatch [:test/inject-sensitive-data "safe"])
+
+      (let [initial-db @(rf/subscribe [:test/sensitive-data])
+            payload {:test/sensitive-data "pwned"
+                     :user-input {:editor {:default {:code "hacked"}}}}
+            encoded (share/encode-state payload)]
+
+        (is (= "safe" initial-db) "Initial sensitive data should be 'safe'")
+        (is (some? encoded) "Encoding should succeed")
+
+        ;; 2. Load shared state which contains malicious override
+        (rf/dispatch [::core/load-shared-state encoded])
+
+        ;; 3. Check if sensitive data was overwritten
+        (let [new-db @(rf/subscribe [:test/sensitive-data])
+              new-code (get-in @(rf/subscribe [::core/user-input]) [:editor :default :code])]
+
+          ;; This assertion should FAIL if the vulnerability exists
+          (is (= "safe" new-db) "Sensitive data should NOT be overwritten by shared state")
+
+          ;; Feature requirement: user-input SHOULD be updated
+          (is (= "hacked" new-code) "User input SHOULD be updated by shared state"))))))


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `::load-shared-state` event blindly merged decoded JSON from the URL query parameter `?state=` into the application database (`app-db`), allowing attackers to overwrite sensitive keys like `[:platform]` or `[:runtime]`.
🎯 Impact: Attackers could inject arbitrary state, potentially leading to UI manipulation, denial of service (by corrupting runtime state), or facilitating social engineering attacks.
🔧 Fix: Whitelisted `[:user-input]` in the `::load-shared-state` event handler using `select-keys`.
✅ Verification: Added `security_test.cljs` which asserts that sensitive keys cannot be overwritten via the state mechanism. Ran `npm test`.

---
*PR created automatically by Jules for task [15473986646459565202](https://jules.google.com/task/15473986646459565202) started by @davidpham87*