### PR TITLE
Refactor malli inference tests for direct equality

### DIFF
--- a/test/bb_web_ds_tools/components/malli_inference_test.cljs
+++ b/test/bb_web_ds_tools/components/malli_inference_test.cljs
@@ -2,16 +2,6 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [bb-web-ds-tools.components.malli :as sut]))
 
-(defn get-field-schema [schema field]
-  (let [schema-def (if (vector? schema) schema schema)
-        entries (if (= :map (first schema-def))
-                  (rest schema-def)
-                  [])
-        entry (first (filter #(= field (first %)) entries))]
-    (if entry
-      (second entry)
-      nil)))
-
 (deftest test-refine-schema-with-data
   (testing "New Logic: Enum if Unique <= 200 AND (Unique < 10% OR MaxLen < 60)"
 
@@ -19,8 +9,8 @@
       (let [unique-vals (map #(str "Val" %) (range 50))
             data (vec (mapcat (fn [v] (repeat 20 {:a v})) unique-vals))
             res (sut/infer-schema data)
-            schema (:schema res)]
-        (is (= :enum (first (get-field-schema schema :a))))))
+            expected-enum (into [:enum] (sort unique-vals))]
+        (is (= {:success true :schema [:map [:a expected-enum]]} res))))
 
     (testing "Scenario 2: Small Dataset (10 rows), 3 unique values"
       ;; Unique=3. (30%). Length < 60.
@@ -28,16 +18,14 @@
       (let [data (vec (repeat 10 {:a "Cat"}))
             data (assoc-in data [1 :a] "Dog")
             data (assoc-in data [2 :a] "Fish")
-            res (sut/infer-schema data)
-            schema (:schema res)]
-        (is (= [:enum "Cat" "Dog" "Fish"] (get-field-schema schema :a)))))
+            res (sut/infer-schema data)]
+        (is (= {:success true :schema [:map [:a [:enum "Cat" "Dog" "Fish"]]]} res))))
 
     (testing "Scenario 3: Large Dataset, ID Column (High Cardinality)"
       ;; Unique=1000. Fails 200 limit. -> String.
       (let [data (mapv (fn [i] {:a (str "ID" i)}) (range 1000))
-            res (sut/infer-schema data)
-            schema (:schema res)]
-        (is (= :string (get-field-schema schema :a)))))
+            res (sut/infer-schema data)]
+        (is (= {:success true :schema [:map [:a :string]]} res))))
 
     (testing "Scenario 4: Medium Dataset, Unique < 200, but > 10%, Short Strings"
       ;; Unique=50. Total=100. (50%). Length < 60.
@@ -45,23 +33,21 @@
       (let [unique-vals (map #(str "V" %) (range 50))
             data (vec (mapcat (fn [v] (repeat 2 {:a v})) unique-vals))
             res (sut/infer-schema data)
-            schema (:schema res)]
-        (is (= :enum (first (get-field-schema schema :a))))))
+            expected-enum (into [:enum] (sort unique-vals))]
+        (is (= {:success true :schema [:map [:a expected-enum]]} res))))
 
     (testing "Scenario 5: Long Strings (Description)"
       ;; MaxLen=70. Total=100. Unique=1. (1%).
       ;; OR condition satisfies logic (Unique < 10%). -> Enum.
       (let [long-str (apply str (repeat 70 "X"))
             data (vec (repeat 100 {:a long-str}))
-            res (sut/infer-schema data)
-            schema (:schema res)]
-        (is (= :enum (first (get-field-schema schema :a))))))
+            res (sut/infer-schema data)]
+        (is (= {:success true :schema [:map [:a [:enum long-str]]]} res))))
 
     (testing "Scenario 6: Long Strings, High Percentage"
       ;; MaxLen=70. Unique=10. Total=20. (50%).
       ;; Fails OR condition (Neither < 10% nor < 60). -> String.
       (let [unique-vals (map #(str (apply str (repeat 70 "X")) %) (range 10))
             data (vec (mapcat (fn [v] (repeat 2 {:a v})) unique-vals))
-            res (sut/infer-schema data)
-            schema (:schema res)]
-        (is (= :string (get-field-schema schema :a)))))))
+            res (sut/infer-schema data)]
+        (is (= {:success true :schema [:map [:a :string]]} res))))))


### PR DESCRIPTION
Refactored `test/bb_web_ds_tools/components/malli_inference_test.cljs` to compare the full function result against expected values instead of extracting and checking individual fields. This simplifies the tests and ensures the complete output structure is verified.

Changes:
- Removed `get-field-schema` helper.
- Updated all test scenarios to use `(is (= expected-map actual-map))`.
- For large generated datasets, the expected enum vector is constructed programmatically using `sort` to ensure test maintainability while still verifying the full structure.

---
*PR created automatically by Jules for task [9409285060834116115](https://jules.google.com/task/9409285060834116115) started by @davidpham87*