### PR TITLE
Fix SQLite WASM tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
         "storybook": "storybook dev -p 6006",
         "build-storybook": "storybook build",
         "dev-stories": "npx shadow-cljs watch stories",
-        "postinstall": "mkdir -p docs/js/libs/vs docs/css docs/js/libs/monaco-esm && cp -r node_modules/monaco-editor/min/vs/* docs/js/libs/vs/ && cp -r node_modules/monaco-editor/esm/* docs/js/libs/monaco-esm/ && cp node_modules/@sqlite.org/sqlite-wasm/sqlite-wasm/jswasm/sqlite3.js docs/js/libs/ && cp node_modules/@sqlite.org/sqlite-wasm/sqlite-wasm/jswasm/sqlite3.wasm docs/js/libs/"
+        "postinstall": "mkdir -p docs/js/libs/vs docs/css docs/js/libs/monaco-esm && cp -r node_modules/monaco-editor/min/vs/* docs/js/libs/vs/ && cp -r node_modules/monaco-editor/esm/* docs/js/libs/monaco-esm/ && cp node_modules/@sqlite.org/sqlite-wasm/sqlite-wasm/jswasm/sqlite3.js docs/js/libs/ && cp node_modules/@sqlite.org/sqlite-wasm/sqlite-wasm/jswasm/sqlite3.wasm docs/js/libs/ && node scripts/patch_sqlite.js"
     }
 }

--- a/scripts/patch_sqlite.js
+++ b/scripts/patch_sqlite.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+const filePath = path.join('node_modules', '@sqlite.org/sqlite-wasm/sqlite-wasm/jswasm/sqlite3.mjs');
+
+if (fs.existsSync(filePath)) {
+  let content = fs.readFileSync(filePath, 'utf8');
+  const search = "Module['locateFile'] =";
+  const replace = "if (!Module['locateFile']) Module['locateFile'] =";
+
+  if (content.includes(search) && !content.includes(replace)) {
+    content = content.replace(search, replace);
+    fs.writeFileSync(filePath, content, 'utf8');
+    console.log('Patched sqlite3.mjs');
+  } else {
+    console.log('sqlite3.mjs already patched or search pattern not found');
+  }
+} else {
+  // Silent or warn, but don't fail as it might be a different environment or install phase
+  console.warn('sqlite3.mjs not found at', filePath);
+}

--- a/test/bb_web_ds_tools/persistence_test.cljs
+++ b/test/bb_web_ds_tools/persistence_test.cljs
@@ -13,9 +13,11 @@
          (go
            (try
              (let [config (clj->js {:print (fn [x] (js/console.log "SQLite:" x))
-                                    :printErr (fn [x] (js/console.error "SQLite Err:" x))})
+                                    :printErr (fn [x] (js/console.error "SQLite Err:" x))
+                                    :locateFile (fn [file _] (str "/base/target/test/" file))})
                    sqlite3 (<p! (sqlite3InitModule config))]
                (is (some? sqlite3) "SQLite module loaded")
+               (reset! pfx/sqlite-lib sqlite3)
                (let [sqlite3 ^js sqlite3
                      oo1 (.-oo1 sqlite3)
                      DB (.-DB ^js oo1)


### PR DESCRIPTION
This change fixes the `persistence-test` which was failing to load the SQLite WASM module in the test environment (Karma).

The fix involves:
1.  Patching `@sqlite.org/sqlite-wasm` via a `postinstall` script to allow overriding the `locateFile` function.
2.  Configuring `locateFile` in the test to point to the correct path served by Karma (`/base/target/test/`).
3.  Ensuring the global `sqlite-lib` atom is populated in the test so that `export-db` and other functions work correctly.

---
*PR created automatically by Jules for task [6143333282625724467](https://jules.google.com/task/6143333282625724467) started by @davidpham87*