### PR TITLE
Refactor vega-lite-test to use static value assertions

### DIFF
--- a/test/bb_web_ds_tools/views/vega_lite_test.cljs
+++ b/test/bb_web_ds_tools/views/vega_lite_test.cljs
@@ -6,7 +6,6 @@
             [bb-web-ds-tools.views.vega-lite.events :as events]
             [bb-web-ds-tools.views.vega-lite.subs :as subs]
             [bb-web-ds-tools.core :as core]
-            [clojure.edn :as edn]
             [bb-web-ds-tools.test-setup :as setup]))
 
 (use-fixtures :each setup/suppress-re-frame-warnings)
@@ -24,15 +23,9 @@
    (testing "JSON to EDN conversion"
      (rf/dispatch [::events/set-config-mode :edn])
      (is (= :edn @(rf/subscribe [::subs/config-mode])))
-     (let [config @(rf/subscribe [::subs/config-input])]
-       (is (string? config))
-        ;; Verify content matches {:a 1}
-       (is (= {:a 1} (edn/read-string config)) "Should be valid EDN matching original JSON")))
+     (is (= "{:a 1}\n" @(rf/subscribe [::subs/config-input]))))
 
    (testing "EDN to JSON conversion"
      (rf/dispatch [::events/set-config-mode :json])
      (is (= :json @(rf/subscribe [::subs/config-mode])))
-     (let [config @(rf/subscribe [::subs/config-input])]
-       (is (string? config))
-       (let [parsed (js->clj (js/JSON.parse config) :keywordize-keys true)]
-         (is (= {:a 1} parsed) "Should be valid JSON matching EDN"))))))
+     (is (= "{\n  \"a\": 1\n}" @(rf/subscribe [::subs/config-input]))))))


### PR DESCRIPTION
Refactored `test/bb_web_ds_tools/views/vega_lite_test.cljs` to verify `config-input` string values directly instead of parsing them and checking the resulting data structure. This reduces test complexity and reliance on intermediate variables, as requested.

Removed unused `clojure.edn` dependency from the test namespace.

---
*PR created automatically by Jules for task [550671027081483324](https://jules.google.com/task/550671027081483324) started by @davidpham87*