### PR TITLE
Fix failing tests and SQLite WASM loading

### DIFF
--- a/test/bb_web_ds_tools/persistence_test.cljs
+++ b/test/bb_web_ds_tools/persistence_test.cljs
@@ -16,6 +16,7 @@
                                     :printErr (fn [x] (js/console.error "SQLite Err:" x))})
                    sqlite3 (<p! (sqlite3InitModule config))]
                (is (some? sqlite3) "SQLite module loaded")
+               (reset! pfx/sqlite-lib sqlite3)
                (let [sqlite3 ^js sqlite3
                      oo1 (.-oo1 sqlite3)
                      DB (.-DB ^js oo1)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,6 +57,15 @@ const commonConfig = {
         }
       },
       {
+        test: /sqlite-wasm\/jswasm\/sqlite3\.mjs$/,
+        type: 'javascript/auto',
+        parser: {
+          javascript: {
+            url: false
+          }
+        }
+      },
+      {
         test: /\.css$/i,
         oneOf: [
           {
@@ -119,7 +128,7 @@ const commonConfig = {
 module.exports = [
   Object.assign({}, commonConfig, {
     name: 'app',
-    entry: './target/index.js',
+    entry: ['./target/index.js', './node_modules/@sqlite.org/sqlite-wasm/sqlite-wasm/jswasm/sqlite3.wasm'],
     output: {
       path: path.resolve(__dirname, 'docs/js'),
       filename: 'libs.js',
@@ -129,7 +138,7 @@ module.exports = [
   }),
   Object.assign({}, commonConfig, {
     name: 'test',
-    entry: './target/test/npm-index.js',
+    entry: ['./target/test/npm-index.js', './node_modules/@sqlite.org/sqlite-wasm/sqlite-wasm/jswasm/sqlite3.wasm'],
     output: {
       path: path.resolve(__dirname, 'target/test'),
       filename: 'libs.js',


### PR DESCRIPTION
Fixed an issue where `sqlite3.wasm` could not be loaded in the test environment by disabling Webpack's `new URL` dependency parsing for `sqlite3.mjs` and explicitly including the WASM file in the Webpack entry. Also fixed a `null` pointer exception in `persistence_test.cljs` by properly initializing the global `sqlite-lib` atom.

---
*PR created automatically by Jules for task [11234095412468331300](https://jules.google.com/task/11234095412468331300) started by @davidpham87*