### PR TITLE
Refactor malli inference tests to use static value assertions

### DIFF
--- a/test/bb_web_ds_tools/components/malli_inference_test.cljs
+++ b/test/bb_web_ds_tools/components/malli_inference_test.cljs
@@ -2,25 +2,16 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [bb-web-ds-tools.components.malli :as sut]))
 
-(defn get-field-schema [schema field]
-  (let [schema-def (if (vector? schema) schema schema)
-        entries (if (= :map (first schema-def))
-                  (rest schema-def)
-                  [])
-        entry (first (filter #(= field (first %)) entries))]
-    (if entry
-      (second entry)
-      nil)))
-
 (deftest test-refine-schema-with-data
   (testing "New Logic: Enum if Unique <= 200 AND (Unique < 10% OR MaxLen < 60)"
 
     (testing "Scenario 1: Large Dataset, Low Cardinality (Standard Enum)"
       (let [unique-vals (map #(str "Val" %) (range 50))
             data (vec (mapcat (fn [v] (repeat 20 {:a v})) unique-vals))
-            res (sut/infer-schema data)
-            schema (:schema res)]
-        (is (= :enum (first (get-field-schema schema :a))))))
+            res (sut/infer-schema data)]
+        (is (= {:success true
+                :schema [:map [:a [:enum "Val0" "Val1" "Val10" "Val11" "Val12" "Val13" "Val14" "Val15" "Val16" "Val17" "Val18" "Val19" "Val2" "Val20" "Val21" "Val22" "Val23" "Val24" "Val25" "Val26" "Val27" "Val28" "Val29" "Val3" "Val30" "Val31" "Val32" "Val33" "Val34" "Val35" "Val36" "Val37" "Val38" "Val39" "Val4" "Val40" "Val41" "Val42" "Val43" "Val44" "Val45" "Val46" "Val47" "Val48" "Val49" "Val5" "Val6" "Val7" "Val8" "Val9"]]]}
+               res))))
 
     (testing "Scenario 2: Small Dataset (10 rows), 3 unique values"
       ;; Unique=3. (30%). Length < 60.
@@ -28,40 +19,45 @@
       (let [data (vec (repeat 10 {:a "Cat"}))
             data (assoc-in data [1 :a] "Dog")
             data (assoc-in data [2 :a] "Fish")
-            res (sut/infer-schema data)
-            schema (:schema res)]
-        (is (= [:enum "Cat" "Dog" "Fish"] (get-field-schema schema :a)))))
+            res (sut/infer-schema data)]
+        (is (= {:success true
+                :schema [:map [:a [:enum "Cat" "Dog" "Fish"]]]}
+               res))))
 
     (testing "Scenario 3: Large Dataset, ID Column (High Cardinality)"
       ;; Unique=1000. Fails 200 limit. -> String.
       (let [data (mapv (fn [i] {:a (str "ID" i)}) (range 1000))
-            res (sut/infer-schema data)
-            schema (:schema res)]
-        (is (= :string (get-field-schema schema :a)))))
+            res (sut/infer-schema data)]
+        (is (= {:success true
+                :schema [:map [:a :string]]}
+               res))))
 
     (testing "Scenario 4: Medium Dataset, Unique < 200, but > 10%, Short Strings"
       ;; Unique=50. Total=100. (50%). Length < 60.
       ;; OR condition satisfies logic (Length < 60). -> Enum.
       (let [unique-vals (map #(str "V" %) (range 50))
             data (vec (mapcat (fn [v] (repeat 2 {:a v})) unique-vals))
-            res (sut/infer-schema data)
-            schema (:schema res)]
-        (is (= :enum (first (get-field-schema schema :a))))))
+            res (sut/infer-schema data)]
+        (is (= {:success true
+                :schema [:map [:a [:enum "V0" "V1" "V10" "V11" "V12" "V13" "V14" "V15" "V16" "V17" "V18" "V19" "V2" "V20" "V21" "V22" "V23" "V24" "V25" "V26" "V27" "V28" "V29" "V3" "V30" "V31" "V32" "V33" "V34" "V35" "V36" "V37" "V38" "V39" "V4" "V40" "V41" "V42" "V43" "V44" "V45" "V46" "V47" "V48" "V49" "V5" "V6" "V7" "V8" "V9"]]]}
+               res))))
 
     (testing "Scenario 5: Long Strings (Description)"
       ;; MaxLen=70. Total=100. Unique=1. (1%).
       ;; OR condition satisfies logic (Unique < 10%). -> Enum.
       (let [long-str (apply str (repeat 70 "X"))
             data (vec (repeat 100 {:a long-str}))
-            res (sut/infer-schema data)
-            schema (:schema res)]
-        (is (= :enum (first (get-field-schema schema :a))))))
+            res (sut/infer-schema data)]
+        (is (= {:success true
+                :schema [:map [:a [:enum "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"]]]}
+               res))))
 
     (testing "Scenario 6: Long Strings, High Percentage"
       ;; MaxLen=70. Unique=10. Total=20. (50%).
       ;; Fails OR condition (Neither < 10% nor < 60). -> String.
       (let [unique-vals (map #(str (apply str (repeat 70 "X")) %) (range 10))
             data (vec (mapcat (fn [v] (repeat 2 {:a v})) unique-vals))
-            res (sut/infer-schema data)
-            schema (:schema res)]
-        (is (= :string (get-field-schema schema :a)))))))
+            res (sut/infer-schema data)]
+        (is (= {:success true
+                :schema [:map [:a :string]]}
+               res))))))


### PR DESCRIPTION
Refactored `test/bb_web_ds_tools/components/malli_inference_test.cljs` to use direct map equality checks for `sut/infer-schema` results, capturing the full expected output structure (including long enum lists) instead of checking individual properties. This simplifies the test logic and ensures strict regression testing for the inferred schema structure.

---
*PR created automatically by Jules for task [11994867567446231088](https://jules.google.com/task/11994867567446231088) started by @davidpham87*