### PR TITLE
🛡️ Sentinel: Enforce sample limit in Malli generator to prevent DoS

### DIFF
--- a/src/bb_web_ds_tools/components/malli.cljc
+++ b/src/bb_web_ds_tools/components/malli.cljc
@@ -120,6 +120,8 @@
     (catch #?(:cljs :default :clj Exception) e
       {:success false :error (str "Invalid schema EDN: " (ex-message e))})))
 
+(def max-samples 10000)
+
 (defn generate-data
   "Generates random data from a Malli schema.
 
@@ -132,17 +134,19 @@
     map: {:success true :output string :data any}."
   [schema samples format]
   (if (and schema (pos? samples))
-    (try
-      (let [data (if (> samples 1)
-                   (vec (repeatedly samples #(mg/generate schema)))
-                   (mg/generate schema))
-            output (case format
-                     :edn (pretty-print-str data)
-                     :json (generate-json data)
-                     (pr-str data))]
-        {:success true :output output :data data})
-      (catch #?(:cljs :default :clj Exception) e
-        {:success false :error (str "Generation failed: " (ex-message e))}))
+    (if (> samples max-samples)
+      {:success false :error (str "Sample count exceeds maximum limit of " max-samples ".")}
+      (try
+        (let [data (if (> samples 1)
+                     (vec (repeatedly samples #(mg/generate schema)))
+                     (mg/generate schema))
+              output (case format
+                       :edn (pretty-print-str data)
+                       :json (generate-json data)
+                       (pr-str data))]
+          {:success true :output output :data data})
+        (catch #?(:cljs :default :clj Exception) e
+          {:success false :error (str "Generation failed: " (ex-message e))})))
     {:success false :error "Invalid schema or samples."}))
 
 (declare annotate-schema)

--- a/test/bb_web_ds_tools/components/malli_test.cljc
+++ b/test/bb_web_ds_tools/components/malli_test.cljc
@@ -115,3 +115,16 @@
                          {:min d1
                           :max d3}]]]}
              (sut/infer-schema data))))))
+
+(deftest generate-data-limit-test
+  (testing "generate-data respects max sample limit"
+    (let [schema [:map [:a int?]]
+          result (sut/generate-data schema 10001 :edn)]
+      (is (not (:success result)))
+      (is (= "Sample count exceeds maximum limit of 10000." (:error result)))))
+
+  (testing "generate-data works within limit"
+    (let [schema [:map [:a int?]]
+          result (sut/generate-data schema 10 :edn)]
+      (is (:success result))
+      (is (= 10 (count (:data result)))))))


### PR DESCRIPTION
This PR adds a security enhancement to the Malli data generation component.

**Security Issue:**
The `generate-data` function previously accepted any positive integer for the `samples` argument. A user could inadvertently or maliciously request a very large number of samples (e.g., 1,000,000), causing the application (running on the browser main thread or via CLI) to freeze or crash due to excessive memory and CPU usage (Resource Exhaustion / Denial of Service).

**Fix:**
I have enforced a hard limit of **10,000** samples per generation request.

**Changes:**
- Modified `src/bb_web_ds_tools/components/malli.cljc` to add the limit check.
- Added `test/bb_web_ds_tools/components/malli_test.cljc` to verify the limit is enforced correctly.

**Verification:**
Ran unit tests using `clojure -M:test -d test -n bb-web-ds-tools.components.malli-test`. All tests passed.

---
*PR created automatically by Jules for task [9018260439905757960](https://jules.google.com/task/9018260439905757960) started by @davidpham87*