### PR TITLE
Fix SQLite WASM loading in Karma tests

### DIFF
--- a/test/bb_web_ds_tools/persistence_test.cljs
+++ b/test/bb_web_ds_tools/persistence_test.cljs
@@ -12,10 +12,30 @@
   (async done
          (go
            (try
-             (let [config (clj->js {:print (fn [x] (js/console.log "SQLite:" x))
-                                    :printErr (fn [x] (js/console.error "SQLite Err:" x))})
+             ;; Configure sqlite3InitModule to load WASM manually, bypassing the default loader
+             ;; which fails in the Webpack/Karma environment due to dynamic import.meta.url usage.
+             (let [base-config (clj->js {:print (fn [x] (js/console.log "SQLite:" x))
+                                         :printErr (fn [x] (js/console.error "SQLite Err:" x))
+                                         :instantiateWasm (fn [imports success-cb]
+                                                            (-> (js/fetch "/base/target/test/sqlite3.wasm")
+                                                                (.then #(.arrayBuffer %))
+                                                                (.then #(js/WebAssembly.instantiate % imports))
+                                                                (.then (fn [result]
+                                                                         (success-cb (.-instance result) (.-module result))
+                                                                         result))))})
+                   ;; Use a Proxy to prevent sqlite3.mjs from overwriting our instantiateWasm implementation
+                   handler (clj->js {:set (fn [target prop value receiver]
+                                            (if (or (= prop "instantiateWasm")
+                                                    (= prop "locateFile"))
+                                              true ;; Ignore overwrite
+                                              (js/Reflect.set target prop value receiver)))})
+                   config (new js/Proxy base-config handler)
                    sqlite3 (<p! (sqlite3InitModule config))]
                (is (some? sqlite3) "SQLite module loaded")
+
+               ;; Initialize the atom used by persistence-fx, which expects global state
+               (reset! pfx/sqlite-lib sqlite3)
+
                (let [sqlite3 ^js sqlite3
                      oo1 (.-oo1 sqlite3)
                      DB (.-DB ^js oo1)
@@ -43,9 +63,8 @@
                      (is (instance? js/Blob blob) "Export returns a Blob")
                      (is (> (.-size blob) 0) "Blob is not empty")))))
              (catch :default e
-          ;; In some CI/Test environments, loading WASM assets might fail due to path issues.
-          ;; We catch this to prevent build failure, but log it.
                (js/console.warn "SQLite WASM initialization failed (expected if WASM assets are missing in test env):" (.-message e))
-               (is true "Skipping SQLite tests due to environment limitations"))
+               (is false (str "Test failed with exception: " (.-message e))))
              (finally
+               (reset! pfx/sqlite-lib nil) ;; Cleanup
                (done))))))


### PR DESCRIPTION
Modified `test/bb_web_ds_tools/persistence_test.cljs` to fix SQLite tests. 
The tests were previously swallowing errors because the default WASM loading logic in `sqlite3.mjs` (using `import.meta.url`) is incompatible with the Webpack/Karma setup, causing "Cannot find module" errors.
The fix involves:
1. Fetching `sqlite3.wasm` manually from the test server.
2. Providing a custom `instantiateWasm` handler.
3. Using a `Proxy` on the configuration object to prevent `sqlite3.mjs` from overwriting the custom handler.
4. Correctly initializing the global `pfx/sqlite-lib` atom required by the persistence logic.

---
*PR created automatically by Jules for task [3253459964731013312](https://jules.google.com/task/3253459964731013312) started by @davidpham87*