### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix CSV formula injection in CLI

### DIFF
--- a/src/bb_web_ds_tools/impl/io.clj
+++ b/src/bb_web_ds_tools/impl/io.clj
@@ -24,6 +24,19 @@
 
 (defmulti write-string (fn [format _] (keyword format)))
 
+(defn- sanitize-value
+  "Sanitizes a value for CSV/TSV export to prevent formula injection.
+   Prepends a single quote if the string starts with =, +, -, or @."
+  [v]
+  (if (and (string? v) (re-find #"^[=\+\-@]" v))
+    (str "'" v)
+    v))
+
+(defn- sanitize-row
+  "Sanitizes all values in a row (vector)."
+  [row]
+  (mapv sanitize-value row))
+
 (defmethod write-string :csv
   [_ data]
   (let [sw (java.io.StringWriter.)]
@@ -33,16 +46,16 @@
                         header (keys (first row-maps))
                         rows (map (fn [row] (map #(get row %) header))
                                   row-maps)]
-                    (csv/write-csv sw (cons header rows)))
+                    (csv/write-csv sw (map sanitize-row (cons header rows))))
       ;; If vector of vectors (rows), use directly
       (and (sequential? data) (sequential? (first data))) (csv/write-csv sw
-                                                                         data)
+                                                                         (map sanitize-row data))
       ;; Default: Assume row-maps
       :else (if (empty? data)
               ""
               (let [header (keys (first data))
                     rows (map (fn [row] (map #(get row %) header)) data)]
-                (csv/write-csv sw (cons header rows)))))
+                (csv/write-csv sw (map sanitize-row (cons header rows))))))
     (.toString sw)))
 
 (defmethod write-string :json [_ data] (json/write-str data {:indent true}))

--- a/test/bb_web_ds_tools/impl/io_test.clj
+++ b/test/bb_web_ds_tools/impl/io_test.clj
@@ -1,0 +1,18 @@
+(ns bb-web-ds-tools.impl.io-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [bb-web-ds-tools.impl.io :as sut]
+            [clojure.string :as str]))
+
+(deftest csv-injection-test
+  (testing "Formula injection characters are escaped"
+    (let [data [{:a "=cmd" :b "+cmd" :c "-cmd" :d "@cmd" :e "safe"}]
+          csv (sut/write-string :csv data)]
+      (is (str/includes? csv "'=cmd"))
+      (is (str/includes? csv "'+cmd"))
+      (is (str/includes? csv "'-cmd"))
+      (is (str/includes? csv "'@cmd"))
+      (is (str/includes? csv "safe"))
+      (is (not (str/includes? csv "\n=cmd")))
+      (is (not (str/includes? csv "\n+cmd")))
+      (is (not (str/includes? csv "\n-cmd")))
+      (is (not (str/includes? csv "\n@cmd"))))))


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix CSV formula injection in CLI

**Vulnerability:** CSV Injection (Formula Injection)
**Impact:** If a user uses the CLI tool to convert malicious data (e.g., JSON containing formula payloads) to CSV, and then opens that CSV in spreadsheet software, the payload could execute (e.g., launching calculator, exfiltrating data).
**Fix:** Implemented input sanitization in `bb-web-ds-tools.impl.io/write-string` for CSV format. Values starting with dangerous characters (`=`, `+`, `-`, `@`) are now escaped with a leading single quote (`'`).
**Verification:** Added `test/bb_web_ds_tools/impl/io_test.clj` verifying that dangerous characters are escaped. Confirmed fix with local reproduction script.

---
*PR created automatically by Jules for task [15831163568869228409](https://jules.google.com/task/15831163568869228409) started by @davidpham87*