### PR TITLE
🛡️ Sentinel: Fix SQL Injection in Persistence Layer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -38,3 +38,8 @@
 **Vulnerability:** User-controlled data exported to CSV/TSV could contain formulas (starting with =, +, -, @) that execute when opened in Excel/Google Sheets.
 **Learning:** Standard regex matching (`re-matches .*`) in ClojureScript/JS does not match newlines by default, allowing bypass via multiline strings.
 **Prevention:** Use `re-find` with start-of-string anchor (`^...`) instead of `re-matches` with `.*`, or enable dot-all mode if full matching is required.
+
+## 2026-02-05 - [SQL Injection in Persistence Layer]
+**Vulnerability:** Manual string concatenation was used to construct SQL INSERT statements in `persistence_fx.cljs`, allowing potential SQL injection via unescaped inputs (e.g., dataset IDs).
+**Learning:** `sqlite-wasm` supports parameterized queries via the `:bind` option in `.exec`, which should always be used instead of manual escaping.
+**Prevention:** Refactored `persist-all!` and `persist-datasets!` to use `{:sql "..." :bind [...]}` parameters.

--- a/src/bb_web_ds_tools/workspaces/persistence_fx.cljs
+++ b/src/bb_web_ds_tools/workspaces/persistence_fx.cljs
@@ -62,53 +62,39 @@
     nil: Side effect."
   [db]
   (create-tables! db)
-  (let [workspaces (d/q '[:find ?id ?name ?created ?updated
-                          :where
-                          [?e :workspace/id ?id]
-                          [?e :workspace/name ?name]
-                          [?e :workspace/created-at ?created]
-                          [?e :workspace/updated-at ?updated]]
-                        @ws/conn)
-        inputs (d/q '[:find ?id ?ws-id ?type ?name ?content ?meta ?updated
-                      :where
-                      [?e :input/id ?id]
-                      [?e :input/workspace ?ws-ref]
-                      [?ws-ref :workspace/id ?ws-id]
-                      [?e :input/type ?type]
-                      [?e :input/name ?name]
-                      [?e :input/content ?content]
-                      [?e :input/metadata ?meta]
-                      [?e :input/updated-at ?updated]]
-                    @ws/conn)
-
-        ;; Prepare SQL statements
-        ws-inserts (map (fn [[id name ^js created ^js updated]]
-                          (str "INSERT INTO workspaces VALUES ("
-                               "'" id "', "
-                               "'" (str/replace name "'" "''") "', "
-                               (.getTime created) ", "
-                               (.getTime updated) ");"))
-                        workspaces)
-        input-inserts (map (fn [[id ws-id type name content meta ^js updated]]
-                             (str "INSERT INTO inputs VALUES ("
-                                  "'" id "', "
-                                  "'" ws-id "', "
-                                  "'" (name type) "', "
-                                  "'" (str/replace name "'" "''") "', "
-                                  "'" (str/replace content "'" "''") "', "
-                                  "'" (str/replace (pr-str meta) "'" "''") "', "
-                                  (.getTime updated) ");"))
-                           inputs)
-
-        all-sql (str/join "\n"
-                          (concat ["BEGIN TRANSACTION;"
-                                   "DELETE FROM workspaces;"
-                                   "DELETE FROM inputs;"]
-                                  ws-inserts
-                                  input-inserts
-                                  ["COMMIT;"]))]
-    (.exec db all-sql)
-    (println "Persisted to in-memory SQL DB.")))
+  (.exec db "BEGIN TRANSACTION;")
+  (try
+    (.exec db "DELETE FROM workspaces;")
+    (.exec db "DELETE FROM inputs;")
+    (let [workspaces (d/q '[:find ?id ?name ?created ?updated
+                            :where
+                            [?e :workspace/id ?id]
+                            [?e :workspace/name ?name]
+                            [?e :workspace/created-at ?created]
+                            [?e :workspace/updated-at ?updated]]
+                          @ws/conn)
+          inputs (d/q '[:find ?id ?ws-id ?type ?name ?content ?meta ?updated
+                        :where
+                        [?e :input/id ?id]
+                        [?e :input/workspace ?ws-ref]
+                        [?ws-ref :workspace/id ?ws-id]
+                        [?e :input/type ?type]
+                        [?e :input/name ?name]
+                        [?e :input/content ?content]
+                        [?e :input/metadata ?meta]
+                        [?e :input/updated-at ?updated]]
+                      @ws/conn)]
+      (doseq [[id name ^js created ^js updated] workspaces]
+        (.exec db (clj->js {:sql "INSERT INTO workspaces VALUES (?, ?, ?, ?)"
+                            :bind [id name (.getTime created) (.getTime updated)]})))
+      (doseq [[id ws-id type name content meta ^js updated] inputs]
+        (.exec db (clj->js {:sql "INSERT INTO inputs VALUES (?, ?, ?, ?, ?, ?, ?)"
+                            :bind [id ws-id (name type) name content (pr-str meta) (.getTime updated)]}))))
+    (.exec db "COMMIT;")
+    (println "Persisted to in-memory SQL DB.")
+    (catch :default e
+      (.exec db "ROLLBACK;")
+      (throw e))))
 
 (defn persist-datasets!
   "Persists user datasets to the SQLite DB using Transit encoding.
@@ -121,22 +107,19 @@
     nil: Side effect."
   [db datasets-map]
   (create-tables! db)
-  (let [ds-inserts (map (fn [[id dataset]]
-                          (let [encoded (transit-encode dataset)
-                                created-at (js/Date.now)]
-                            (str "INSERT INTO datasets VALUES ("
-                                 "'" id "', "
-                                 "'" (str/replace (:name dataset) "'" "''") "', "
-                                 "'" (str/replace encoded "'" "''") "', "
-                                 created-at ");")))
-                        datasets-map)
-        all-sql (str/join "\n"
-                          (concat ["BEGIN TRANSACTION;"
-                                   "DELETE FROM datasets;"]
-                                  ds-inserts
-                                  ["COMMIT;"]))]
-    (.exec db all-sql)
-    (println "Datasets persisted to DB.")))
+  (.exec db "BEGIN TRANSACTION;")
+  (try
+    (.exec db "DELETE FROM datasets;")
+    (doseq [[id dataset] datasets-map]
+      (let [encoded (transit-encode dataset)
+            created-at (js/Date.now)]
+        (.exec db (clj->js {:sql "INSERT INTO datasets VALUES (?, ?, ?, ?)"
+                            :bind [id (:name dataset) encoded created-at]}))))
+    (.exec db "COMMIT;")
+    (println "Datasets persisted to DB.")
+    (catch :default e
+      (.exec db "ROLLBACK;")
+      (throw e))))
 
 (defn load-datasets-from-db
   "Loads datasets from the SQLite DB.

--- a/test/bb_web_ds_tools/persistence_test.cljs
+++ b/test/bb_web_ds_tools/persistence_test.cljs
@@ -38,6 +38,15 @@
                      (let [loaded (pfx/load-datasets-from-db db)]
                        (is (= datasets loaded)))))
 
+                 (testing "SQL Injection Resilience"
+                   (let [evil-id "evil' OR 1=1 --"
+                         datasets {evil-id {:name "Evil Dataset" :data []}}]
+                     ;; With vulnerable code, this might fail or create weird rows
+                     ;; With fixed code, it should store ID literally
+                     (pfx/persist-datasets! db datasets)
+                     (let [rows (.exec db "SELECT id FROM datasets WHERE id=?" (clj->js {:bind [evil-id] :returnValue "resultRows"}))]
+                       (is (= [[evil-id]] (js->clj rows)) "Malicious ID stored correctly"))))
+
                  (testing "Export DB"
                    (let [blob (pfx/export-db db)]
                      (is (instance? js/Blob blob) "Export returns a Blob")


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix SQL Injection in Persistence Layer

🚨 Severity: CRITICAL
💡 Vulnerability: The application was manually constructing SQL INSERT statements by concatenating strings and using insufficient escaping (replacing `'` with `''`). This allowed potential SQL injection if input data (like dataset IDs) contained malicious payloads.
🎯 Impact: An attacker could corrupt the local SQLite database, drop tables, or potentially execute arbitrary SQL commands within the browser context.
🔧 Fix: Refactored `persist-all!` and `persist-datasets!` in `src/bb_web_ds_tools/workspaces/persistence_fx.cljs` to use parameterized queries supported by `sqlite-wasm`. This ensures inputs are treated as data, not code.
✅ Verification: Added a test case in `persistence_test.cljs` that attempts to insert a dataset with a SQL injection payload (`evil' OR 1=1 --`). While the test environment has limitations running WASM, the code refactor was verified via inspection and follows security best practices.

---
*PR created automatically by Jules for task [15683064832579440413](https://jules.google.com/task/15683064832579440413) started by @davidpham87*