### PR TITLE
Fix sqlite3 WASM loading in tests

### DIFF
--- a/scripts/sqlite-patch-loader.js
+++ b/scripts/sqlite-patch-loader.js
@@ -1,0 +1,10 @@
+module.exports = function(source) {
+  const search = "return new URL(path, import.meta.url).href;";
+  const replace = `
+      if (path === "sqlite3.wasm") {
+        return new URL("sqlite3.wasm", import.meta.url).href;
+      }
+      return new URL(path, import.meta.url).href;
+  `;
+  return source.replace(search, replace);
+};

--- a/test/bb_web_ds_tools/persistence_test.cljs
+++ b/test/bb_web_ds_tools/persistence_test.cljs
@@ -13,10 +13,15 @@
          (go
            (try
              (let [config (clj->js {:print (fn [x] (js/console.log "SQLite:" x))
-                                    :printErr (fn [x] (js/console.error "SQLite Err:" x))})
+                                    :printErr (fn [x] (js/console.error "SQLite Err:" x))
+                                    :locateFile (fn [file _script-dir]
+                                                  (if (= file "sqlite3.wasm")
+                                                    "/base/target/test/sqlite3.wasm"
+                                                    file))})
                    sqlite3 (<p! (sqlite3InitModule config))]
                (is (some? sqlite3) "SQLite module loaded")
                (let [sqlite3 ^js sqlite3
+                     _ (reset! pfx/sqlite-lib sqlite3)
                      oo1 (.-oo1 sqlite3)
                      DB (.-DB ^js oo1)
                      db (new DB ":memory:" "ct")]
@@ -42,10 +47,5 @@
                    (let [blob (pfx/export-db db)]
                      (is (instance? js/Blob blob) "Export returns a Blob")
                      (is (> (.-size blob) 0) "Blob is not empty")))))
-             (catch :default e
-          ;; In some CI/Test environments, loading WASM assets might fail due to path issues.
-          ;; We catch this to prevent build failure, but log it.
-               (js/console.warn "SQLite WASM initialization failed (expected if WASM assets are missing in test env):" (.-message e))
-               (is true "Skipping SQLite tests due to environment limitations"))
              (finally
                (done))))))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -111,6 +111,14 @@ const commonConfig = {
         generator: {
           filename: '[name][ext]'
         }
+      },
+      {
+        test: /sqlite3\.mjs$/,
+        use: [
+          {
+            loader: path.resolve('scripts/sqlite-patch-loader.js')
+          }
+        ]
       }
     ],
   },


### PR DESCRIPTION
Fixed the failing/skipped persistence tests by resolving the `sqlite3.wasm` loading issue in the Webpack + Karma environment. This involved patching `sqlite3.mjs` via a custom loader to make it compatible with Webpack 5's asset handling and properly initializing the application state in the test.

---
*PR created automatically by Jules for task [1403799346283099010](https://jules.google.com/task/1403799346283099010) started by @davidpham87*